### PR TITLE
[PLAT-674] Feat: Mod Registry

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+MATIC_RPC_URL=

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ docker compose down
 ```
 
 ```bash
-sudo docker rm resolution-subgraph_graph-node_1 && sudo docker rm resolution-subgraph_ipfs_1 && sudo docker rm resolution-subgraph_postgres_1 && sudo docker rm resolution-subgraph_ganache_1
+sudo docker rm resolution-subgraph-graph-node-1 && sudo docker rm resolution-subgraph-ipfs-1 && sudo docker rm resolution-subgraph-postgres-1 && sudo docker rm resolution-subgraph-ganache-1
 ```
 
 ## Create and deploy subgraph

--- a/abis/ModRegistry.json
+++ b/abis/ModRegistry.json
@@ -1,0 +1,218 @@
+[
+    {
+        "type": "function",
+        "name": "addAdmin",
+        "inputs": [
+            {
+                "name": "admin",
+                "type": "address",
+                "internalType": "address"
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "addMod",
+        "inputs": [
+            {
+                "name": "user",
+                "type": "address",
+                "internalType": "address"
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "admins",
+        "inputs": [
+            {
+                "name": "",
+                "type": "address",
+                "internalType": "address"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "isAdmin",
+        "inputs": [
+            {
+                "name": "addr",
+                "type": "address",
+                "internalType": "address"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "",
+                "type": "bool",
+                "internalType": "bool"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "isMod",
+        "inputs": [
+            {
+                "name": "user",
+                "type": "address",
+                "internalType": "address"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "",
+                "type": "bool",
+                "internalType": "bool"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "moderators",
+        "inputs": [
+            {
+                "name": "",
+                "type": "address",
+                "internalType": "address"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "",
+                "type": "bool",
+                "internalType": "bool"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "removeAdmin",
+        "inputs": [
+            {
+                "name": "admin",
+                "type": "address",
+                "internalType": "address"
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "removeMod",
+        "inputs": [
+            {
+                "name": "user",
+                "type": "address",
+                "internalType": "address"
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "renounceAdmin",
+        "inputs": [],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "event",
+        "name": "ModAdded",
+        "inputs": [
+            {
+                "name": "admin",
+                "type": "address",
+                "indexed": true,
+                "internalType": "address"
+            },
+            {
+                "name": "addedMod",
+                "type": "address",
+                "indexed": true,
+                "internalType": "address"
+            }
+        ],
+        "anonymous": false
+    },
+    {
+        "type": "event",
+        "name": "ModRemoved",
+        "inputs": [
+            {
+                "name": "admin",
+                "type": "address",
+                "indexed": true,
+                "internalType": "address"
+            },
+            {
+                "name": "removedMod",
+                "type": "address",
+                "indexed": true,
+                "internalType": "address"
+            }
+        ],
+        "anonymous": false
+    },
+    {
+        "type": "event",
+        "name": "NewAdmin",
+        "inputs": [
+            {
+                "name": "admin",
+                "type": "address",
+                "indexed": true,
+                "internalType": "address"
+            },
+            {
+                "name": "newAdminAddress",
+                "type": "address",
+                "indexed": true,
+                "internalType": "address"
+            }
+        ],
+        "anonymous": false
+    },
+    {
+        "type": "event",
+        "name": "RemovedAdmin",
+        "inputs": [
+            {
+                "name": "admin",
+                "type": "address",
+                "indexed": true,
+                "internalType": "address"
+            },
+            {
+                "name": "removedAdmin",
+                "type": "address",
+                "indexed": true,
+                "internalType": "address"
+            }
+        ],
+        "anonymous": false
+    },
+    {
+        "type": "error",
+        "name": "NotAdmin",
+        "inputs": []
+    }
+]

--- a/generated/schema.ts
+++ b/generated/schema.ts
@@ -278,3 +278,56 @@ export class AncillaryDataHashToQuestionId extends Entity {
     this.set("questionId", Value.fromString(value));
   }
 }
+
+export class Moderator extends Entity {
+  constructor(id: string) {
+    super();
+    this.set("id", Value.fromString(id));
+  }
+
+  save(): void {
+    let id = this.get("id");
+    assert(id != null, "Cannot save Moderator entity without an ID");
+    if (id) {
+      assert(
+        id.kind == ValueKind.STRING,
+        `Entities of type Moderator must have an ID of type String but the id '${id.displayData()}' is of type ${id.displayKind()}`
+      );
+      store.set("Moderator", id.toString(), this);
+    }
+  }
+
+  static loadInBlock(id: string): Moderator | null {
+    return changetype<Moderator | null>(store.get_in_block("Moderator", id));
+  }
+
+  static load(id: string): Moderator | null {
+    return changetype<Moderator | null>(store.get("Moderator", id));
+  }
+
+  get id(): string {
+    let value = this.get("id");
+    if (!value || value.kind == ValueKind.NULL) {
+      throw new Error("Cannot return null for a required field.");
+    } else {
+      return value.toString();
+    }
+  }
+
+  set id(value: string) {
+    this.set("id", Value.fromString(value));
+  }
+
+  get canMod(): boolean {
+    let value = this.get("canMod");
+    if (!value || value.kind == ValueKind.NULL) {
+      return false;
+    } else {
+      return value.toBoolean();
+    }
+  }
+
+  set canMod(value: boolean) {
+    this.set("canMod", Value.fromBoolean(value));
+  }
+}

--- a/schema.graphql
+++ b/schema.graphql
@@ -18,3 +18,8 @@ type AncillaryDataHashToQuestionId @entity {
   id: String! # ancillaryDataHash
   questionId: String! # questionID
 }
+
+type Moderator @entity {
+  id: String! # address
+  canMod: Boolean! # bool
+}

--- a/src/mod-registry.ts
+++ b/src/mod-registry.ts
@@ -1,0 +1,34 @@
+import { BigInt, Address, log } from "@graphprotocol/graph-ts";
+import { ModAdded, ModRemoved } from "../generated/ModRegistry/ModRegistry";
+import { Moderator } from "../generated/schema";
+
+export function handleModAdded(event: ModAdded): void {
+    log.info("mod added in transaction {}", [event.transaction.hash.toHexString()]);
+    let modAddress = event.params.addedMod.toHexString();
+    let mod = Moderator.load(modAddress);
+    if(mod == null) {
+        // first time mod has been added
+        mod = new Moderator(modAddress);
+        mod.canMod = true;
+    } else {
+        // Mod was added before but removed
+        mod.canMod = true;
+    }
+    mod.save();
+}
+
+export function handleModRemoved(event: ModRemoved): void {
+    log.info("mod removed in transaction {}", [event.transaction.hash.toHexString()]);
+    let modAddress = event.params.removedMod.toHexString();
+    let mod = Moderator.load(modAddress);
+    if(mod == null) {
+        // mod removed before it was added
+        // should not be possible due to how events are emitted but handle that case
+        mod = new Moderator(modAddress);
+        mod.canMod = false;
+    } else {
+        // Mod removed
+        mod.canMod = false;
+    }
+    mod.save();
+}

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -169,3 +169,25 @@ dataSources:
             address,bytes32,uint256,bytes,address,uint256,uint256)
           handler: handleRequestPrice
       file: ./src/optimistic-oracle-old.ts
+  - kind: ethereum
+    name: ModRegistry
+    network: matic
+    source:
+      abi: ModRegistry
+      address: "0xe1c9271516930B9e1355b87232556a0f39D3aBD3"
+      startBlock: 52699785
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - Moderator
+      abis:
+        - name: ModRegistry
+          file: ./abis/ModRegistry.json
+      eventHandlers:
+        - event: ModAdded(indexed address,indexed address)
+          handler: handleModAdded
+        - event: ModRemoved(indexed address,indexed address)
+          handler: handleModRemoved
+      file: ./src/mod-registry.ts


### PR DESCRIPTION
- Add the ModRegistry to the resolution-subgraph
- On ModAdded event, a new Moderator entity is created, keyed on address with a field `canMod` set to true
- On ModRemoved event, load the existing Moderator entity and set `canMod` to false

So to get available mods, can simply use a query like the below:
```
{
  moderators(first:100, where:{canMod: true}) {
    id
    canMod
  }
}
```

Or after sql injestion: `SELECT * FROM moderators WHERE can_mod=true;`